### PR TITLE
fix bug in non_blocking.rs

### DIFF
--- a/src/bin/non_blocking.rs
+++ b/src/bin/non_blocking.rs
@@ -123,7 +123,7 @@ fn main() {
             }
         }
 
-        for i in completed {
+        for i in completed.into_iter().rev() {
             connections.remove(i);
         }
     }


### PR DESCRIPTION
we need to iterate over the to remove indexes in reverse order, because otherwise the connections vec would get shifted and the indices would no longer be accurate